### PR TITLE
Fixing NNBD support for ScrollMetrics

### DIFF
--- a/lib/vs_scrollbar.dart
+++ b/lib/vs_scrollbar.dart
@@ -157,7 +157,12 @@ class _ScrollbarState extends State<VsScrollbar> with TickerProviderStateMixin {
 
   bool _handleScrollNotification(ScrollNotification notification) {
     final ScrollMetrics metrics = notification.metrics;
-    if (metrics.maxScrollExtent <= metrics.minScrollExtent) {
+    // Check if metrics has content dimensions before checking
+    // min/maxScrollExtend because the getters are non-nullable and the backing
+    // fields are nullable. hasContentDimensions ensures that the values are
+    // non-null.
+    if (!metrics.hasContentDimensions ||
+        metrics.maxScrollExtent <= metrics.minScrollExtent) {
       return false;
     }
 


### PR DESCRIPTION
When navigating my app and especially when hot reloading/restarting on a page with a vs_scrollbar I get an "Unexpected null value" because the ScrollController have not yet received content dimensions but the _handleScrollNotification checks `metrics.maxScrollExtent`. In my case, the ScrollMetrics was of type FixedScrollMetrics and the implementation of maxScrollExtent looks like this (scroll_metrics.dart:150, flutter beta 1.26):
```
  @override
  double get maxScrollExtent => _maxScrollExtent!;
  final double? _maxScrollExtent;
```

We also have this check to see if scroll extent is null:
```
@override
  bool get hasContentDimensions => _minScrollExtent != null && _maxScrollExtent != null;
```

The fix in my PR makes sure we do not compare null values.