### PR TITLE
handle new isPointerOverScrollbar API

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.2.1"
 sdks:
   dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/vs_scrollbar.dart
+++ b/lib/vs_scrollbar.dart
@@ -314,7 +314,7 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   void handleHover(PointerHoverEvent event) {
     super.handleHover(event);
     // Check if the position of the pointer falls over the painted VsScrollbar
-    if (isPointerOverScrollbar(event.position)) {
+    if (isPointerOverScrollbar(event.position, event.kind)) {
       // Pointer is hovering over the VsScrollbar
       setState(() {
         _hoverIsActive = true;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vs_scrollbar
 description: Customizable ScrollBar that can be dragged for quick navigation supporting both Horizontal and Vertical list.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/VickySalunkhe/vs_scrollbar
 repository: https://github.com/VickySalunkhe/vs_scrollbar
 


### PR DESCRIPTION
Fix call to `isPointerOverScrollbar` which now requires [two arguments](https://api.flutter.dev/flutter/widgets/RawScrollbarState/isPointerOverScrollbar.html).

Closes https://github.com/VickySalunkhe/vs_scrollbar/issues